### PR TITLE
Fix AttributeError in 'get_exec_graph_int8layers' function

### DIFF
--- a/model_analyzer/model_metadata.py
+++ b/model_analyzer/model_metadata.py
@@ -202,7 +202,7 @@ class ModelMetaData:
             rt_info = execution_node.get_rt_info()
             layer_type = rt_info['layerType']
             inputs_number = (
-                1 if layer_type.lower() in {'convolution', 'deconvolution', 'fullyconnected', 'gemm', 'pooling'}
+                1 if str(layer_type).lower() in {'convolution', 'deconvolution', 'fullyconnected', 'gemm', 'pooling'}
                 else len(execution_node.inputs())
             )
             input_precisions = [


### PR DESCRIPTION
### Description
This pull request addresses an AttributeError that occurs when calling the `lower()` method on an `OVAny` object within the `get_exec_graph_int8layers` function. 

### Changes Made
Updated the `get_exec_graph_int8layers` function to convert `layer_type` to a string before calling the `lower()` method. 

**Related Issue** https://github.com/openvinotoolkit/model_analyzer/issues/115


